### PR TITLE
fix proxy, firewall service and kubespray errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cp -r examples/group_vars examples/host_vars .
 
 5. Update group and host vars to match your desired configuration.
 
-Note: Please pay special attention to the `http_proxy`, `https_proxy` and `no_proxy` vars in the `proxy_env` dictionary if your behind proxy. Don't forget to add all cluster nodes IP addresses to the `no_proxy` to avoid many potential problems!
+Note: Please pay special attention to the `http_proxy`, `https_proxy` and `no_proxy` vars if you're behind proxy. Don't forget to add all cluster nodes IP addresses to the `no_proxy` to avoid many potential problems!
 
 6. Execute `ansible-playbook`.
 ```
@@ -38,7 +38,7 @@ ansible-playbook -i inventory.ini playbooks/cluster.yml
 
 ## Requirements
 * Python 2 present on the target servers.
-* Ansible 2.7.1 (or newer) installed on the Ansible machine (the one you run these playbooks from).
+* Ansible >=2.7.1,<=2.7.10 installed on the Ansible machine (the one you run these playbooks from).
 * pip==9.0.3 installed on the Ansible machine.
 * SSH keys copied to all Kubernetes cluster nodes (`ssh-copy-id <user>@<host>` command can be used for that).
 * Internet access on all target servers is mandatory. Proxy is supported.

--- a/examples/group_vars/all.yml
+++ b/examples/group_vars/all.yml
@@ -33,10 +33,9 @@ gpu_dp_namespace: kube-system
 force_external_multus_installation: true
 
 ## Proxy configuration ##
-#proxy_env:
-#  http_proxy: "http://proxy.example.com:1080"
-#  https_proxy: "http://proxy.example.com:1080"
-#  no_proxy: "localhost,127.0.0.1,.example.com,10.0.0.1,10.0.0.2,10.0.0.3,10.0.0.4,10.0.0.5,10.0.0.0/24"
+http_proxy: "http://proxy.example.com:1080"
+https_proxy: "http://proxy.example.com:1080"
+no_proxy: "localhost,127.0.0.1,.example.com,10.0.0.1,10.0.0.2,10.0.0.3,10.0.0.4,10.0.0.5,10.0.0.0/24"
 
 ## Kubespray variables ##
 
@@ -52,5 +51,5 @@ helm_enabled: true
 
 # Docker registry running on the cluster allows us to store images not avaialble on Docker Hub, e.g. CMK
 registry_enabled: true
-registry_storage_class: null
+registry_storage_class: ""
 registry_local_address: "localhost:5000"

--- a/playbooks/infra/infra_setup.yml
+++ b/playbooks/infra/infra_setup.yml
@@ -1,6 +1,7 @@
 - hosts: k8s-cluster
   tasks: []
   roles:
+    - { role: cluster-defaults }
     - { role: k8s-all-preconfigure }
   environment: "{{ proxy_env | d({}) }}"
   any_errors_fatal: true
@@ -8,6 +9,7 @@
 - hosts: kube-node
   tasks: []
   roles:
+    - { role: cluster-defaults }
     - { role: k8s-node-preconfigure }
   environment: "{{ proxy_env | d({}) }}"
   any_errors_fatal: true

--- a/playbooks/intel/bmra_features.yml
+++ b/playbooks/intel/bmra_features.yml
@@ -3,6 +3,8 @@
 - hosts: k8s-cluster
   tasks: []
   roles:
+    - role: cluster-defaults
+      tags: defaults
     - role: golang-install
       tags: golang
     - role: multus-cni-install
@@ -28,6 +30,8 @@
 - hosts: kube-node
   tasks: []
   roles:
+    - role: cluster-defaults
+      tags: defaults
     - role: dpdk-install
       when: ovs_dpdk_enabled
       tags: dpdk

--- a/playbooks/k8s/k8s.yml
+++ b/playbooks/k8s/k8s.yml
@@ -27,9 +27,6 @@
     kubeadm_enabled: true
     kube_api_anonymous_auth: true
     docker_iptables_enabled: true
-    http_proxy: "{{ proxy_env.http_proxy | default('') }}"
-    https_proxy: "{{ proxy_env.https_proxy | default('') }}"
-    additional_no_proxy: "{{ proxy_env.no_proxy | default('') }},"
 
 - hosts: k8s-cluster
   tasks:

--- a/roles/cluster-defaults/defaults/main.yml
+++ b/roles/cluster-defaults/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+proxy_env:
+  http_proxy: "{{ http_proxy | default ('') }}"
+  https_proxy: "{{ https_proxy | default ('') }}"
+  no_proxy: "{{ no_proxy | default ('') }}"

--- a/roles/cluster-defaults/tasks/main.yml
+++ b/roles/cluster-defaults/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Set defaults
+  debug:
+    msg: "Setting defaults from roles/cluster-defaults/defaults/main.yml"

--- a/roles/k8s-all-preconfigure/tasks/main.yml
+++ b/roles/k8s-all-preconfigure/tasks/main.yml
@@ -90,6 +90,7 @@
       Debian: firewall
       Ubuntu: ufw
   become: yes
+  failed_when: false # some distros don't include any firewall services, we try to disable them here in best effort mode
 
 # note: this uses "failed_when: false" for the cases where br_netfilter is built Linux into kernel and not listed as a module
 # please see here for more information: https://github.com/kubernetes/kubernetes/issues/23385

--- a/roles/kubespray-install/files/requirements.txt
+++ b/roles/kubespray-install/files/requirements.txt
@@ -1,0 +1,7 @@
+ansible>=2.7.6,<=2.7.10
+jinja2>=2.9.6
+netaddr
+pbr>=1.6
+hvac
+jmespath
+ruamel.yaml

--- a/roles/kubespray-install/tasks/main.yml
+++ b/roles/kubespray-install/tasks/main.yml
@@ -16,4 +16,4 @@
 
 - name: install kubespray python requirements
   pip:
-    requirements: "{{ playbook_dir }}/kubespray/requirements.txt"
+    requirements: "{{ role_path }}/files/requirements.txt"


### PR DESCRIPTION
* update README after recent fixes
* refactor proxy configuration
* don't fail when firewall service is missing
* update example configuration
* lock Ansible version required by Kubespray 2.9