### PR TITLE
fix cni plugins installation

### DIFF
--- a/roles/sriov-cni-install/tasks/main.yml
+++ b/roles/sriov-cni-install/tasks/main.yml
@@ -26,4 +26,5 @@
   copy:
     src: /usr/src/sriov-cni/build/sriov
     dest: /opt/cni/bin/sriov
+    mode: 0755
     remote_src: yes

--- a/roles/userspace-cni-install/tasks/main.yml
+++ b/roles/userspace-cni-install/tasks/main.yml
@@ -45,3 +45,4 @@
     remote_src: yes
     src: "{{ userspace_cni_path }}/userspace/userspace"
     dest: "/opt/cni/bin/userspace"
+    mode: 0755

--- a/roles/userspace-cni-install/tasks/vpp-install.yml
+++ b/roles/userspace-cni-install/tasks/vpp-install.yml
@@ -27,6 +27,14 @@
   when: ansible_os_family == "RedHat"
   register: vpp_sh_rh
 
+- name: write sys config with hugepages and memory settings
+  template:
+    src: 80-vpp.conf.j2
+    dest: /etc/sysctl.d/80-vpp.conf
+
+- name: apply sysctl config
+  command: sysctl -p --load=/etc/sysctl.d/80-vpp.conf
+
 - name: install vpp packages on Red Hat
   yum:
     name:

--- a/roles/userspace-cni-install/tasks/vpp-install.yml
+++ b/roles/userspace-cni-install/tasks/vpp-install.yml
@@ -27,6 +27,23 @@
   when: ansible_os_family == "RedHat"
   register: vpp_sh_rh
 
+- name: capture sysctl configuration
+  command: sysctl -n kernel.shmmax vm.nr_hugepages vm.max_map_count
+  register: original_sysctl
+
+- name: calc intermediate VPP sysctl entries values
+  set_fact:
+    vpp_orig_shmmax: "{{ original_sysctl.stdout_lines[0] }}"
+    vpp_orig_max_map_count: "{{  original_sysctl.stdout_lines[2] }}"
+    vpp_calc_shmmax: "{{ (default_hugepage_size == '2M') | ternary(hugepages_2M*2048*1024, hugepages_1G*1024*1024*1024) }}"
+    vpp_calc_max_map_count: "{{ (default_hugepage_size == '2M') | ternary(hugepages_2M*3, hugepages_1G*3) }}"
+
+- name: pick final sysctl entries values
+  set_fact:
+    vpp_nr_hugepages: "{{  original_sysctl.stdout_lines[1] }}"
+    vpp_shmmax: "{{ [vpp_calc_shmmax|int, vpp_orig_shmmax|int] | max }}"
+    vpp_max_map_count: "{{ [vpp_orig_max_map_count|int, vpp_calc_max_map_count|int] | max }}"
+
 - name: install vpp packages on Red Hat
   yum:
     name:

--- a/roles/userspace-cni-install/tasks/vpp-install.yml
+++ b/roles/userspace-cni-install/tasks/vpp-install.yml
@@ -27,14 +27,6 @@
   when: ansible_os_family == "RedHat"
   register: vpp_sh_rh
 
-- name: write sys config with hugepages and memory settings
-  template:
-    src: 80-vpp.conf.j2
-    dest: /etc/sysctl.d/80-vpp.conf
-
-- name: apply sysctl config
-  command: sysctl -p --load=/etc/sysctl.d/80-vpp.conf
-
 - name: install vpp packages on Red Hat
   yum:
     name:
@@ -61,6 +53,14 @@
       - vpp-api-java
     state: present
   when: ansible_os_family == "Debian"
+
+- name: write sys config with hugepages and memory settings
+  template:
+    src: 80-vpp.conf.j2
+    dest: /etc/sysctl.d/80-vpp.conf
+
+- name: apply sysctl config
+  command: sysctl -p --load=/etc/sysctl.d/80-vpp.conf
 
 # NOTE: questions:
 #       do we need to update vpp config to apply some optimizations?

--- a/roles/userspace-cni-install/templates/80-vpp.conf.j2
+++ b/roles/userspace-cni-install/templates/80-vpp.conf.j2
@@ -1,0 +1,5 @@
+{% if default_hugepage_size == "1G" %}
+vm.nr_hugepages={{ hugepages_1G }}
+{% else %}
+vm.nr_hugepages={{ hugepages_2M }}
+{% endif %}

--- a/roles/userspace-cni-install/templates/80-vpp.conf.j2
+++ b/roles/userspace-cni-install/templates/80-vpp.conf.j2
@@ -1,5 +1,4 @@
-{% if default_hugepage_size == "1G" %}
-vm.nr_hugepages={{ hugepages_1G }}
-{% else %}
-vm.nr_hugepages={{ hugepages_2M }}
-{% endif %}
+vm.nr_hugepages={{ vpp_nr_hugepages }}
+vm.max_map_count={{ vpp_max_map_count }}
+kernel.shmmax={{ vpp_shmmax }}
+vm.hugetlb_shm_group=0

--- a/roles/userspace-cni-install/vars/main.yml
+++ b/roles/userspace-cni-install/vars/main.yml
@@ -8,6 +8,7 @@ install_dependencies:
     - libtool
     - shtool
     - python-six
+    - wget
   RedHat:
     - git
     - gcc
@@ -17,6 +18,7 @@ install_dependencies:
     - libtool
     - shtool
     - python-six
+    - wget
 
 ovs_dpdk_lcore_mask: 0x1
 ovs_dpdk_pmd_mask: 0x2


### PR DESCRIPTION
- fix an issue where sriov-cni and userspace-cni plugins had incorrect permissions set after copying to /opt/cni/bin directory
- add sysctl configuration file to be used by VPP, so that the original hugepages configuration from the host_vars is preserved
- add missing dependency (wget) for userspace-cni Makefile