### PR TITLE
add node remove feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ Note: Please pay special attention to the `http_proxy`, `https_proxy` and `addit
 ansible-playbook -i inventory.ini playbooks/cluster.yml
 ```
 
+## Remove node
+
+You may want to remove worker nodes from your existing cluster after it has been deployed. This can be done by running the `playbooks/remove-node.yml` playbook.
+
+> Note: The node you want to remove needs to be present in the inventory file. Also, it is highly recommended to use the same configuration defined in the group\_vars and host\_vars as during the deployment or cluster scale up.
+
+Use `--extra-vars "node=<nodenameX>,<nodenameY>"` in the below `ansible-playbook` command to select the node or nodes you want to delete, for example:
+```
+ansible-playbook -i inventory/inventory.ini playbooks/remove-node.yml \
+                 --extra-vars "node=node2,node4"
+```
+
 ## Requirements
 * Python 2 present on the target servers.
 * Ansible >=2.7.1,<=2.7.10 installed on the Ansible machine (the one you run these playbooks from).

--- a/playbooks/infra/remove-node.yml
+++ b/playbooks/infra/remove-node.yml
@@ -1,0 +1,4 @@
+---
+- hosts: "{{ node | default('kube-node') }}"
+  roles:
+    - { role: node-reset }

--- a/playbooks/intel/remove-node.yml
+++ b/playbooks/intel/remove-node.yml
@@ -1,0 +1,4 @@
+---
+- hosts: "{{ node | default('kube-node') }}"
+  roles:
+    - { role: features-reset }

--- a/playbooks/remove-node.yml
+++ b/playbooks/remove-node.yml
@@ -1,0 +1,18 @@
+---
+- name: run kubespray remove-node playbook
+  import_playbook: k8s/kubespray/remove-node.yml
+  tags: kubespray
+  vars:
+    # NOTE(przemeklal): bin_dir is always this, as we don't support CoreOS
+    bin_dir: /usr/local/bin
+    kubeadm_enabled: true
+    kube_api_anonymous_auth: true
+    docker_iptables_enabled: true
+
+- name: remove Intel Container Experience Kits features
+  import_playbook: intel/remove-node.yml
+  tags: intel
+
+- name: reset system configuration performed on the node
+  import_playbook: infra/remove-node.yml
+  tags: infra


### PR DESCRIPTION
Introduce set of playbooks for resetting state of a single node only.
Workloads are rescheduled (except daemonsets) and files are removed,
effectively resetting target machine to the initial state.