### PR TITLE
devbind: add role for binding PCI devices to kernel modules

### DIFF
--- a/roles/devbind/tasks/main.yml
+++ b/roles/devbind/tasks/main.yml
@@ -79,30 +79,30 @@
       state: present
 
   - name: unbind device from its current driver
-    shell: echo {{ pci_address }} > /sys/bus/pci/drivers/{{ dev_info.Driver }}/unbind
+    shell: echo -n {{ pci_address }} > /sys/bus/pci/drivers/{{ dev_info.Driver }}/unbind
     when: '"Driver" in dev_info'
 
   - name: override device driver
-    shell: echo {{ driver }} > /sys/bus/pci/devices/{{ pci_address }}/driver_override
+    shell: echo -n {{ driver }} > /sys/bus/pci/devices/{{ pci_address }}/driver_override
     when:
     - driver in dpdk_drivers
     - ansible_kernel is version_compare('3.15', '>=')
 
   - name: add device id to the driver
-    shell: echo {{ pci_address }} > /sys/bus/pci/drivers/{{ driver }}/new_id
+    shell: echo -n {{ pci_address }} > /sys/bus/pci/drivers/{{ driver }}/new_id
     when:
     - driver in dpdk_drivers
     - ansible_kernel is version_compare('3.15', '<')
 
   - name: bind device to the driver
-    shell: echo {{ pci_address }} > /sys/bus/pci/drivers/{{ driver }}/bind
+    shell: echo -n {{ pci_address }} > /sys/bus/pci/drivers/{{ driver }}/bind
 
   - name: check if driver_override exists
     stat: path=/sys/bus/pci/devices/{{ pci_address }}/driver_override
     register: driver_override
 
   - name: write empty string to driver_override to allow binding to another drivers in the future
-    shell: echo "" > /sys/bus/pci/devices/{{ pci_address }}/driver_override
+    shell: echo -n "" > /sys/bus/pci/devices/{{ pci_address }}/driver_override
     when:
     - ansible_kernel is version_compare('3.15', '>=')
     - driver_override.stat.exists

--- a/roles/devbind/tasks/main.yml
+++ b/roles/devbind/tasks/main.yml
@@ -1,0 +1,95 @@
+---
+# "devbind" role binds network device to the requested kernel driver.
+# Usage: set "pci_address" and "driver" variables
+#  - name: use devbind
+#    include_role:
+#      name: devbind
+#    vars:
+#      driver: uio_pci_generic
+#      pci_address: "{{ item }}"
+#    with_items:
+#      - "0000:02:0f.6"
+#      - "0000:02:0f.7"
+
+- name: get PCI device details
+  block:
+  - name: get PCI device details
+    shell: lspci -vmmks {{ pci_address }}
+    register: lspci
+
+  - name: parse PCI device details
+    set_fact:
+      dev_info: "{{ lspci.stdout | replace('\t',' ') | from_yaml }}"
+      interfaces: []
+
+  - name: find network interfaces associated with the device
+    find:
+      paths: '{{ "/sys/bus/pci/devices/" + pci_address + "/net" }}'
+      recurse: no
+      file_type: any
+    register: ls
+
+  - name: create list of network interfaces names
+    set_fact:
+      interfaces: "{{ interfaces + [(item | basename)] }}"
+    with_items: "{{ ls.files | map(attribute='path') | list }}"
+
+  - name: add network interfaces names to device info
+    set_fact:
+      dev_info: "{{ dev_info | combine({ 'Interfaces': interfaces }) }}"
+
+- name: fail if network device is active in the routing table
+  block:
+  - name: get routing table
+    shell: ip -o route
+    register: ip_route
+
+  - name: filter link local routes
+    set_fact:
+      routes: "{{ ip_route.stdout_lines | reject('search', '169.254') | list }}"
+
+  - name: assert that none of the interfaces are active in the routing table
+    assert:
+      that: "routes | select('search', item) | list | length == 0"
+      fail_msg: "{{ item }} is active in the routing table, refusing further actions"
+      success_msg: "{{ item }} isn't active in the routing table, continuing..."
+    with_items: "{{ dev_info.Interfaces }}"
+
+  - name: display device information
+    debug: var=dev_info
+
+- name: bind device to the driver
+  block:
+  - name: ensure that kernel module is loaded
+    modprobe:
+      name: "{{ driver }}"
+      state: present
+
+  - name: unbind device from its current driver
+    shell: echo {{ pci_address }} > /sys/bus/pci/drivers/{{ dev_info.Driver }}/unbind
+    when: '"Driver" in dev_info'
+
+  - name: override device driver
+    shell: echo {{ driver }} > /sys/bus/pci/devices/{{ pci_address }}/driver_override
+    when:
+    - driver in dpdk_drivers
+    - ansible_kernel is version_compare('3.15', '>=')
+
+  - name: add device id to the driver
+    shell: echo {{ pci_address }} > /sys/bus/pci/drivers/{{ driver }}/new_id
+    when:
+    - driver in dpdk_drivers
+    - ansible_kernel is version_compare('3.15', '<')
+
+  - name: bind device to the driver
+    shell: echo {{ pci_address }} > /sys/bus/pci/drivers/{{ driver }}/bind
+
+  - name: check if driver_override exists
+    stat: path=/sys/bus/pci/devices/{{ pci_address }}/driver_override
+    register: driver_override
+
+  - name: write empty string to driver_override to allow binding to another drivers in the future
+    shell: echo "" > /sys/bus/pci/devices/{{ pci_address }}/driver_override
+    when:
+    - ansible_kernel is version_compare('3.15', '>=')
+    - driver_override.stat.exists

--- a/roles/devbind/tasks/main.yml
+++ b/roles/devbind/tasks/main.yml
@@ -73,11 +73,6 @@
 - name: bind device to the driver
   when: driver != current_driver
   block:
-  - name: ensure that kernel module is loaded
-    modprobe:
-      name: "{{ driver }}"
-      state: present
-
   - name: unbind device from its current driver
     shell: echo -n {{ pci_address }} > /sys/bus/pci/drivers/{{ dev_info.Driver }}/unbind
     when: '"Driver" in dev_info'

--- a/roles/devbind/tasks/main.yml
+++ b/roles/devbind/tasks/main.yml
@@ -22,6 +22,13 @@
       dev_info: "{{ lspci.stdout | replace('\t',' ') | from_yaml }}"
       interfaces: []
 
+  - name: set current driver info
+    set_fact:
+      current_driver: "{{ dev_info.Driver | default('') }}"
+
+- name: find network links of the device
+  when: driver != current_driver
+  block:
   - name: find network interfaces associated with the device
     find:
       paths: '{{ "/sys/bus/pci/devices/" + pci_address + "/net" }}'
@@ -31,14 +38,20 @@
 
   - name: create list of network interfaces names
     set_fact:
-      interfaces: "{{ interfaces + [(item | basename)] }}"
-    with_items: "{{ ls.files | map(attribute='path') | list }}"
+      interfaces: "{{ interfaces + [(link_path | basename)] }}"
+    loop: "{{ ls.files | map(attribute='path') | list }}"
+    loop_control:
+      loop_var: link_path
 
   - name: add network interfaces names to device info
     set_fact:
       dev_info: "{{ dev_info | combine({ 'Interfaces': interfaces }) }}"
 
+- name: display device information
+  debug: var=dev_info
+
 - name: fail if network device is active in the routing table
+  when: driver != current_driver
   block:
   - name: get routing table
     shell: ip -o route
@@ -50,15 +63,15 @@
 
   - name: assert that none of the interfaces are active in the routing table
     assert:
-      that: "routes | select('search', item) | list | length == 0"
-      fail_msg: "{{ item }} is active in the routing table, refusing further actions"
-      success_msg: "{{ item }} isn't active in the routing table, continuing..."
-    with_items: "{{ dev_info.Interfaces }}"
-
-  - name: display device information
-    debug: var=dev_info
+      that: "routes | select('search', iface) | list | length == 0"
+      fail_msg: "{{ iface }} is active in the routing table, refusing further actions"
+      success_msg: "{{ iface }} isn't active in the routing table, continuing..."
+    loop: "{{ dev_info.Interfaces }}"
+    loop_control:
+      loop_var: iface
 
 - name: bind device to the driver
+  when: driver != current_driver
   block:
   - name: ensure that kernel module is loaded
     modprobe:

--- a/roles/devbind/vars/main.yml
+++ b/roles/devbind/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 dpdk_drivers:
 - igb_uio
-- vfio_pci
+- vfio-pci
 - uio_pci_generic
+

--- a/roles/devbind/vars/main.yml
+++ b/roles/devbind/vars/main.yml
@@ -1,0 +1,5 @@
+---
+dpdk_drivers:
+- igb_uio
+- vfio_pci
+- uio_pci_generic


### PR DESCRIPTION
Add a new role that binds specified network device to the kernel driver.
Usage: set "pci_address" and "driver" variables e.g.
```
tasks:
 - name: use devbind
   include_role:
     name: devbind
   vars:
     driver: uio_pci_generic
     pci_address: "{{ item }}"
   with_items:
     - "0000:02:0f.0"
     - "0000:02:0f.1"
```

Signed-off-by: Przemyslaw Lal <przemyslawx.lal@intel.com>