### PR TITLE
enable topology manager on all nodes

### DIFF
--- a/examples/group_vars/all.yml
+++ b/examples/group_vars/all.yml
@@ -40,8 +40,9 @@ example_net_attach_defs:
 #https_proxy: "http://proxy.example.com:1080"
 #additional_no_proxy: ".example.com"
 
-#Topology Manager flags
-kubelet_node_custom_flags:
+# Custom Kubelet flags with Topology Manager flags included.
+# There are four supported policies: none, best-effort, restricted, single-numa-node.
+kubelet_custom_flags:
   - "--feature-gates=TopologyManager=true"
   - "--topology-manager-policy=best-effort"
 


### PR DESCRIPTION
This change enables topology manager on all nodes in a cluster, including master nodes.