### PR TITLE
fixes for master branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "playbooks/k8s/kubespray"]
 	path = playbooks/k8s/kubespray
 	url = https://github.com/kubernetes-sigs/kubespray.git
-	branch = release-2.12
+	branch = master

--- a/examples/group_vars/all.yml
+++ b/examples/group_vars/all.yml
@@ -40,8 +40,9 @@ example_net_attach_defs:
 #https_proxy: "http://proxy.example.com:1080"
 #additional_no_proxy: ".example.com"
 
-#Topology Manager flags
-kubelet_node_custom_flags:
+# Custom Kubelet flags with Topology Manager flags included.
+# There are four supported policies: none, best-effort, restricted, single-numa-node.
+kubelet_custom_flags:
   - "--feature-gates=TopologyManager=true"
   - "--topology-manager-policy=best-effort"
 

--- a/examples/group_vars/all.yml
+++ b/examples/group_vars/all.yml
@@ -29,9 +29,6 @@ qat_dp_namespace: kube-system
 gpu_dp_enabled: true
 gpu_dp_namespace: kube-system
 
-# Forces installation of the Multus CNI from the official Github repo on top of the Kubespray built-in one
-force_external_multus_installation: true
-
 # Create reference net-attach-def objects
 example_net_attach_defs:
   userspace_ovs_dpdk: false

--- a/examples/host_vars/node1.yml
+++ b/examples/host_vars/node1.yml
@@ -38,11 +38,11 @@ install_ddp_packages: true
 hugepages_enabled: true
 
 # Hugepage sizes available: 2M, 1G
-default_hugepage_size: 2M
+default_hugepage_size: 1G
 
 # Sets how many hugepages of each size should be created
-hugepages_1G: 0
-hugepages_2M: 128
+hugepages_1G: 4
+hugepages_2M: 0
 
 # CPU isolation from Linux scheduler
 isolcpus_enabled: true

--- a/roles/cmk-install/defaults/main.yml
+++ b/roles/cmk-install/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 cmk_git_url: "https://github.com/intel/CPU-Manager-for-Kubernetes.git"
-cmk_version: "v1.4.0"
+# use CMK v1.4.0 + Python 3.4 deprecation fix
+cmk_version: "2ce79a64354b766dd28ff709365b9af18fee8c8a"
 cmk_dir: "/usr/src/cmk"
 
 cmk_untaint_nodes: true

--- a/roles/k8s-all-preconfigure/tasks/main.yml
+++ b/roles/k8s-all-preconfigure/tasks/main.yml
@@ -54,6 +54,22 @@
     update_cache: yes
   when: ansible_os_family == "Debian"
 
+- name: install pip
+  yum:
+    name: python-pip
+  when: ansible_os_family == "RedHat"
+
+- name: install pip
+  apt:
+    name: python-pip
+  when: ansible_os_family == "Debian"
+
+- name: install python-netaddr on Ansible host
+  package:
+    name: python-netaddr
+  delegate_to: localhost
+  become: yes
+
 - name: update all packages on Red Hat OS family
   yum:
     name: '*'

--- a/roles/k8s-node-preconfigure/tasks/main.yml
+++ b/roles/k8s-node-preconfigure/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: install jmespath on the Ansible host
+  pip:
+    name: jmespath
+
 # update i40e and i40evf drivers
 - include: "i40e-drivers-update.yml"
   when: force_nic_drivers_update | default(false) | bool

--- a/roles/k8s-node-preconfigure/vars/main.yml
+++ b/roles/k8s-node-preconfigure/vars/main.yml
@@ -1,6 +1,4 @@
 ---
-default_hugepage_size: "2M"
-
 install_dependencies:
   Debian:
     - build-essential

--- a/roles/userspace-cni-install/defaults/main.yml
+++ b/roles/userspace-cni-install/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 userspace_cni_git_url: "https://github.com/intel/userspace-cni-network-plugin.git"
-userspace_cni_version: "master" # NOTE: or v1.1?
+userspace_cni_version: "v1.2"
 
 vpp_version: 1807
 

--- a/roles/userspace-cni-install/tasks/main.yml
+++ b/roles/userspace-cni-install/tasks/main.yml
@@ -30,12 +30,13 @@
 
 - name: build Userspace CNI plugin
   shell: >
-    source /etc/profile.d/golang.sh;
+    source /etc/profile.d/golang.sh &&
+    make clean &&
     {% if vpp_enabled %}
-    make install-deps;
+    make install-dep &&
     {% endif %}
-    make install;
-    make;
+    make install &&
+    make
   args:
     chdir: "{{ userspace_cni_path }}"
     creates: "{{ userspace_cni_path }}/userspace/userspace"


### PR DESCRIPTION
- fix userspace-cni build issue
- fix CMK Dockerimage build issue
- add missing Python dependencies
- fix issue with setting default hugepage size and change default size to 1GB
- update example configuration
- enable topology manager on all nodes including master
- use Kubespray master branch to be on the latest and greatest