### PR TITLE
allow sriovdp config from group_vars

### DIFF
--- a/examples/group_vars/all.yml
+++ b/examples/group_vars/all.yml
@@ -22,6 +22,29 @@ sriov_net_dp_enabled: true
 sriov_net_dp_namespace: kube-system
 # whether to build and store image locally or use one from public external registry
 sriov_net_dp_build_image_locally: false
+# SR-IOV network device plugin configuration.
+# For more information on supported configuration refer to: https://github.com/intel/sriov-network-device-plugin#configurations
+sriovdp_config_data: |
+    {
+        "resourceList": [{
+                "resourceName": "intel_sriov_netdevice",
+                "selectors": {
+                    "vendors": ["8086"],
+                    "devices": ["154c", "10ed"],
+                    "drivers": ["iavf", "i40evf", "ixgbevf"]
+                }
+            },
+            {
+                "resourceName": "intel_sriov_dpdk",
+                "selectors": {
+                    "vendors": ["8086"],
+                    "devices": ["154c", "10ed"],
+                    "drivers": ["vfio-pci"]
+                }
+            }
+        ]
+    }
+
 
 # Intel Device Plugins for Kubernetes
 qat_dp_enabled: true

--- a/roles/sriov-dp-install/charts/sriov-net-dp/templates/configMap.yaml
+++ b/roles/sriov-dp-install/charts/sriov-net-dp/templates/configMap.yaml
@@ -5,22 +5,4 @@ metadata:
   namespace: {{ .Values.namespace }}
 data:
   config.json: |
-    {
-        "resourceList": [{
-                "resourceName": "intel_sriov_netdevice",
-                "selectors": {
-                    "vendors": ["8086"],
-                    "devices": ["154c", "10ed"],
-                    "drivers": ["i40evf", "ixgbevf"]
-                }
-            },
-            {
-                "resourceName": "intel_sriov_dpdk",
-                "selectors": {
-                    "vendors": ["8086"],
-                    "devices": ["154c", "10ed"],
-                    "drivers": ["vfio-pci"]
-                }
-            }
-        ]
-    }
+    {{ .Values.sriovdp_config_data }}

--- a/roles/sriov-dp-install/defaults/main.yml
+++ b/roles/sriov-dp-install/defaults/main.yml
@@ -8,3 +8,24 @@ sriov_net_dp_namespace: kube-system
 
 
 registry_local_address: "localhost:5000"
+sriovdp_config_data: |
+    {
+        "resourceList": [{
+                "resourceName": "intel_sriov_netdevice",
+                "selectors": {
+                    "vendors": ["8086"],
+                    "devices": ["154c", "10ed"],
+                    "drivers": ["iavf", "i40evf", "ixgbevf"]
+                }
+            },
+            {
+                "resourceName": "intel_sriov_dpdk",
+                "selectors": {
+                    "vendors": ["8086"],
+                    "devices": ["154c", "10ed"],
+                    "drivers": ["vfio-pci"]
+                }
+            }
+        ]
+    }
+

--- a/roles/sriov-dp-install/templates/helm_values.yml.j2
+++ b/roles/sriov-dp-install/templates/helm_values.yml.j2
@@ -10,3 +10,4 @@ configPath: {{ sriov_net_dp_config_path | default("/etc/pcidp/config.json") }}
 
 log:
   level: 10
+sriovdp_config_data: {{ sriovdp_config_data }}

--- a/roles/sriov-dp-install/templates/helm_values.yml.j2
+++ b/roles/sriov-dp-install/templates/helm_values.yml.j2
@@ -10,4 +10,4 @@ configPath: {{ sriov_net_dp_config_path | default("/etc/pcidp/config.json") }}
 
 log:
   level: 10
-sriovdp_config_data: {{ sriovdp_config_data }}
+sriovdp_config_data: '{{ sriovdp_config_data }}'


### PR DESCRIPTION
The sriovdp config was embedded in Helm template and not easily
changeable by user. This change allows user to provide configuration
from group_vars.