### PR TITLE
add role for updating git version

### DIFF
--- a/roles/git2-install/tasks/main.yml
+++ b/roles/git2-install/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+# Role for updating git on RHEL7-based distros to resolve 'go get' issues on some projects
+
+# install deps
+- name: install deps
+  yum:
+    name:
+      - gettext-devel
+      - openssl-devel
+      - perl-CPAN
+      - perl-devel
+      - zlib-devel
+    state: present
+
+- name: download git tarball
+  unarchive:
+    src: "{{ git_tarball_url }}"
+    dest: /usr/src/
+    remote_src: yes
+
+- name: make configure
+  make:
+    target: configure
+    chdir: "/usr/src/git-{{ git_version }}"
+
+- name: configure
+  shell: ./configure --prefix=/usr/local
+  args:
+    chdir: "/usr/src/git-{{ git_version }}"
+
+- name: build
+  make:
+    chdir: "/usr/src/git-{{ git_version }}"
+ 
+- name: install
+  make:
+    target: install
+    chdir: "/usr/src/git-{{ git_version }}"

--- a/roles/git2-install/vars/main.yml
+++ b/roles/git2-install/vars/main.yml
@@ -1,0 +1,3 @@
+---
+git_version: "2.25.1"
+git_tarball_url: "https://github.com/git/git/archive/v{{ git_version }}.tar.gz"


### PR DESCRIPTION
Due to `go get` failing on some projects due to ancient version of git
that ships by default with CentOS 7 and RHEL 7, we need to update it to
2+ before trying to sync those dependencies.

Projects that need git-2.x.x can include this role, e.g.
```
- name: update to git2 on RHEL 7 based distros
  include_role:
    name: git2-install
  when:
    - ansible_distribution == 'RedHat' or ansible_distribution ==
CentOS'
    - ansible_distribution_version < '8'
```

This way it'll be installed only if needed.

Signed-off-by: Przemyslaw Lal <przemyslawx.lal@intel.com>