### PR TITLE
Update OVS and DPDK versions

### DIFF
--- a/roles/dpdk-install/vars/main.yml
+++ b/roles/dpdk-install/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-dpdk_url: http://fast.dpdk.org/rel/dpdk-18.11.1.tar.xz
+dpdk_url: http://fast.dpdk.org/rel/dpdk-19.11.tar.xz
 dpdk_target: x86_64-native-linuxapp-gcc
 
 install_dependencies:

--- a/roles/userspace-cni-install/defaults/main.yml
+++ b/roles/userspace-cni-install/defaults/main.yml
@@ -4,10 +4,10 @@ userspace_cni_version: "v1.2"
 
 vpp_version: 1807
 
-ovs_version: v2.11.0
+ovs_version: v2.13.0
 ovs_dir: /usr/src/ovs
 ovs_repo: https://github.com/openvswitch/ovs.git
 
-dpdk_dir: /usr/src/dpdk-stable-18.11.1
+dpdk_dir: /usr/src/dpdk-19.11
 dpdk_build: '{{ dpdk_dir }}/x86_64-native-linuxapp-gcc'
 dpdk_repo: http://dpdk.org/git/dpdk


### PR DESCRIPTION
DPDK was updated to the version 19.11. OVS was updated to 2.13.0,
which is currently the only version compatible with DPDK 19.11.

Signed-off-by: Martin Klozik <martinx.klozik@intel.com>