### PR TITLE
use pip to install netaddr instead of OS package manager

### DIFF
--- a/roles/k8s-all-preconfigure/tasks/main.yml
+++ b/roles/k8s-all-preconfigure/tasks/main.yml
@@ -65,8 +65,8 @@
   when: ansible_os_family == "Debian"
 
 - name: install python-netaddr on Ansible host
-  package:
-    name: python-netaddr
+  pip:
+    name: netaddr==0.7.19
   delegate_to: localhost
   become: yes
 


### PR DESCRIPTION
Fixes occasional issues experienced on RHEL7-based distros we have
with 'package' module.
Also, pip is more portable and is one of the prerequisites for playbooks
execution.

Signed-off-by: Przemyslaw Lal <przemyslawx.lal@intel.com>