### PR TITLE
fix OVS v2.13.0 installation issues

### DIFF
--- a/roles/userspace-cni-install/tasks/ovs-install.yml
+++ b/roles/userspace-cni-install/tasks/ovs-install.yml
@@ -1,9 +1,25 @@
 ---
+- name: install Python3 from epel-release
+  yum:
+    name:
+      - python36
+      - python36-devel
+    enablerepo: "epel"
+  when:
+    - ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'
+    - ansible_distribution_version < '8'
+
+- name: assert that hugepages are enabled
+  assert:
+    that: hugepages_enabled | default(false)
+    fail_msg: "Hugepages are disabled. Please configure hugepages in the host vars or disable OVS-DPDK installation."
+
 - name: clone OVS git repository
   git:
     repo: '{{ ovs_repo }}'
     dest: '{{ ovs_dir }}'
     version: '{{ ovs_version | default("master") }}'
+    force: yes
   register: ovs_changed
 
 - name: check whether bootstrap is required


### PR DESCRIPTION
* OVS v2.13.0 now requires Python 3 to be present
* Install python36 and python36-devel from epel repo on RHEL7 based
distros
* Ensure that hugepages are enabled
* Force git clone in case when local changes have been made between
deployments

Signed-off-by: Przemyslaw Lal <przemyslawx.lal@intel.com>