### PR TITLE
add ansible 2.9.20 to requirements.txt

### DIFF
--- a/profiles/requirements.txt
+++ b/profiles/requirements.txt
@@ -1,2 +1,3 @@
 ruamel.yaml>=0.16.12
 jinja2>=2.11.2
+ansible==2.9.20


### PR DESCRIPTION
* since ansible in version 2.9.20 is a requirement to run the playbooks
  (and is even checked in the preflight playbook), it should be part of
  the requirements.txt

Signed-off-by: Jan Klare <jan.klare@bisdn.de>