### PR TITLE
evaluate turbo_boost_enabled as bool instead of checking if it's defined

### DIFF
--- a/roles/bootstrap/configure_intel_pstate/tasks/main.yml
+++ b/roles/bootstrap/configure_intel_pstate/tasks/main.yml
@@ -32,4 +32,4 @@
 - name: setup turbo boost
   include_tasks: setup_turbo.yml
   when:
-    - turbo_boost_enabled is defined
+    - turbo_boost_enabled


### PR DESCRIPTION
* the previous check would always try to enable turbo boost, as long as
  the varibale turbo_boost_enabled was defined, no matter if the value
  was set to true or false

Signed-off-by: Jan Klare <jan.klare@bisdn.de>